### PR TITLE
Bump Libre-Production-Line-Time-Setter-Panel from 1.0.3 to 1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,9 @@ Libre is distributed under the [Apache 2.0 License](https://github.com/spruik/li
 
 ## Change Log
 
+- 1.0.2
+  - Bump [Libre-Production-Line-Time-Setter-Panel](https://github.com/Spruik/Libre-Production-Line-Time-Setter-Panel/releases/download/v1.0.4/libre-production-line-time-setter-panel.tar.gz) from 1.0.3 to 1.0.4
+
 - 1.0.1
   - Fix Line Performance Downtime table event duration
   - Fix Line Performance Graph Query Bug

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -46,7 +46,7 @@ RUN cd /var/lib/grafana/plugins \
  && rm libre-reason-codes-crud-tree-chart-panel.tar.gz
 
 RUN cd /var/lib/grafana/plugins \
- && wget https://github.com/Spruik/Libre-Production-Line-Time-Setter-Panel/releases/latest/download/libre-production-line-time-setter-panel.tar.gz \
+ && wget https://github.com/Spruik/Libre-Production-Line-Time-Setter-Panel/releases/download/v1.0.4/libre-production-line-time-setter-panel.tar.gz \
  && mkdir ./libre-production-line-time-setter-panel \
  && tar -xf libre-production-line-time-setter-panel.tar.gz -C ./libre-production-line-time-setter-panel \
  && rm libre-production-line-time-setter-panel.tar.gz


### PR DESCRIPTION
Fixes #4  - Issue was due to incorrect URL partial in open modal