### PR TITLE
Fixed the link to the integration templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Orders be executed by clicking from the list in either `SmartFactory/Line Perfor
 
 ### Integrating Machines
 
-Machines will need to push data to the following buckets and schemas. Some integration templates ![Integration Templates](/integration-templates/README.md) are also provided within this repository.
+Machines will need to push data to the following buckets and schemas. Some [integration templates](/integration-templates/README.md) are also provided within this repository.
 
 #### Availability
 


### PR DESCRIPTION
While going through the readme, I noticed the link to the integration templates is formatted as an image. It should probably be a link to the actual readme document in the corresponding folder, therefore changed it.